### PR TITLE
Improved ProcessTools.RunProgram.

### DIFF
--- a/Tewl/Exceptions/RunProgramException.cs
+++ b/Tewl/Exceptions/RunProgramException.cs
@@ -7,26 +7,34 @@ namespace Tewl.Exceptions {
 	/// Thrown when there is an error running a program.
 	/// </summary>
 	public class RunProgramException: Exception {
-		public RunProgramException( int? errorCode, string message, string processOutput, string processError, Exception innerException = null ): base(
-			getMessage( errorCode, message, processOutput, processError ),
-			innerException ) { }
+		private readonly string message;
+		private readonly int? errorCode;
+		internal string ProcessOutput;
+		internal string ProcessError;
 
-		private static string getMessage( int? errorCode, string message, string processOutput, string processError ) {
-			try {
-				var sb = new StringBuilder();
-				sb.AppendLine( message );
-				if( errorCode != null )
-					sb.AppendLine( "Error code: " + errorCode );
-				if( processOutput != null )
-					sb.AppendLine( "Process Output: " + processOutput );
-				if( processError != null )
-					sb.AppendLine( "Process Error Output: " + processError );
+		public RunProgramException( string message, int? errorCode, Exception innerException = null ):base(null, innerException) {
+			this.message = message;
+			this.errorCode = errorCode;
+		}
 
-				return sb.ToString();
-			}
-			catch {
-				// Could fail with OutOfMemoryException
-				return "";
+		public override string Message {
+			get {
+				try {
+					var sb = new StringBuilder();
+					sb.AppendLine( message );
+					if( errorCode != null )
+						sb.AppendLine( "Error code: " + errorCode );
+					if( ProcessOutput != null )
+						sb.AppendLine( "Process Output: " + ProcessOutput );
+					if( ProcessError != null )
+						sb.AppendLine( "Process Error Output: " + ProcessError );
+
+					return sb.ToString();
+				}
+				catch {
+					// Could fail with OutOfMemoryException
+					return "";
+				}
 			}
 		}
 	}

--- a/Tewl/Exceptions/RunProgramException.cs
+++ b/Tewl/Exceptions/RunProgramException.cs
@@ -17,8 +17,10 @@ namespace Tewl.Exceptions {
 				sb.AppendLine( message );
 				if( errorCode != null )
 					sb.AppendLine( "Error code: " + errorCode );
-				sb.AppendLine( "Process Output: " + processOutput );
-				sb.AppendLine( "Process Error Output: " + processError );
+				if( processOutput != null )
+					sb.AppendLine( "Process Output: " + processOutput );
+				if( processError != null )
+					sb.AppendLine( "Process Error Output: " + processError );
 
 				return sb.ToString();
 			}

--- a/Tewl/Exceptions/RunProgramException.cs
+++ b/Tewl/Exceptions/RunProgramException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Text;
+
+namespace Tewl.Exceptions {
+	/// <inheritdoc />
+	/// <summary>
+	/// Thrown when there is an error running a program.
+	/// </summary>
+	public class RunProgramException: Exception {
+		public RunProgramException( int? errorCode, string message, string processOutput, string processError, Exception innerException = null ): base(
+			getMessage( errorCode, message, processOutput, processError ),
+			innerException ) { }
+
+		private static string getMessage( int? errorCode, string message, string processOutput, string processError ) {
+			try {
+				var sb = new StringBuilder();
+				sb.AppendLine( message );
+				if( errorCode != null )
+					sb.AppendLine( "Error code: " + errorCode );
+				sb.AppendLine( "Process Output: " + processOutput );
+				sb.AppendLine( "Process Error Output: " + processError );
+
+				return sb.ToString();
+			}
+			catch {
+				// Could fail with OutOfMemoryException
+				return "";
+			}
+		}
+	}
+}

--- a/Tewl/Tools/ProcessTools.cs
+++ b/Tewl/Tools/ProcessTools.cs
@@ -20,13 +20,47 @@ namespace Tewl.Tools {
 		/// <param name="workingDirectory">Do not pass null. Pass the empty string for the current working directory.</param>
 		/// <param name="waitForExitTimeout">Waits for given duration for the program exists before throwing an exception. Null will wait for exit indefinitely.!</param>
 		/// <exception cref="RunProgramException">When any error occurs.</exception>
-		/// <returns>The output of the program.</returns>
+		/// <returns>The output of the program. Does not include standard error.</returns>
 		public static string RunProgram( string program, string arguments, string input = "", string workingDirectory = "", TimeSpan? waitForExitTimeout = null ) {
-			Process p;
 			var sbOutput = new StringBuilder();
 			var sbError = new StringBuilder();
 			try {
-				p = new Process();
+				RunProgram(
+					program,
+					arguments,
+					msg => sbOutput.AppendLine( msg ),
+					msg => sbError.AppendLine( msg ),
+					input,
+					workingDirectory,
+					waitForExitTimeout );
+			}
+			catch( RunProgramException e ) {
+				e.ProcessOutput = sbOutput.ToString();
+				e.ProcessError = sbError.ToString();
+				throw;
+			}
+
+			return sbOutput.ToString();
+		}
+
+		/// <summary>
+		/// Runs the specified program with the specified arguments and passes in the specified input. If the program is in a folder that is included in the Path environment variable,
+		/// specify its name only. Otherwise, specify a path to the program. In either case, you do not need ".exe" at the end. Specify the empty string for input
+		/// if you do not wish to pass any input to the program.
+		/// </summary>
+		/// <param name="program">A command or exe.</param>
+		/// <param name="arguments">Do not pass null.</param>
+		/// <param name="outputWriter">A function accepting a line of output.</param>
+		/// <param name="errorOutputWriter">A function accepting a line of error output.</param>
+		/// <param name="input">Do not pass null.</param>
+		/// <param name="workingDirectory">Do not pass null. Pass the empty string for the current working directory.</param>
+		/// <param name="waitForExitTimeout">Waits for given duration for the program exists before throwing an exception. Null will wait for exit indefinitely.!</param>
+		/// <exception cref="RunProgramException">When any error occurs.</exception>
+		public static void RunProgram(
+			string program, string arguments, Action<string> outputWriter, Action<string> errorOutputWriter, string input = "", string workingDirectory = "",
+			TimeSpan? waitForExitTimeout = null ) {
+			try {
+				var p = new Process();
 				p.StartInfo.FileName = program;
 				p.StartInfo.Arguments = arguments;
 				p.StartInfo.CreateNoWindow = true; // prevents command window from appearing
@@ -39,12 +73,13 @@ namespace Tewl.Tools {
 				p.StartInfo.RedirectStandardOutput = true;
 				p.StartInfo.RedirectStandardError = true;
 
-				p.OutputDataReceived += ( o, args ) => getOutputHandler( args, sbOutput );
-				p.ErrorDataReceived += ( o, args ) => getOutputHandler( args, sbError );
+				p.OutputDataReceived += ( o, args ) => getOutputHandler( args, outputWriter );
+				p.ErrorDataReceived += ( o, args ) => getOutputHandler( args, errorOutputWriter );
 
 				if( !p.Start() )
 					throw new ApplicationException( "Process failed to start." );
 
+				int? processExitCode = null;
 				try {
 					// Begin recording output.
 					p.BeginOutputReadLine();
@@ -60,52 +95,38 @@ namespace Tewl.Tools {
 						throw new ApplicationException( $"Process did not exit within timeout '{waitForExitTimeout}'." );
 
 					/* When standard output has been redirected to asynchronous event handlers, it is possible that output processing will not
-				 * have completed when this method returns. To ensure that asynchronous event handling has been completed, call the WaitForExit()
-				 * overload that takes no parameter after receiving a true from this overload.
-				 * https://msdn.microsoft.com/en-us/library/ty0d8k56(v=vs.110)
+					 * have completed when this method returns. To ensure that asynchronous event handling has been completed, call the WaitForExit()
+					 * overload that takes no parameter after receiving a true from this overload.
+					 * https://msdn.microsoft.com/en-us/library/ty0d8k56(v=vs.110)
 				 */
 					// This will wait infinitely.
 					p.WaitForExit();
 
-					var processExitCode = p.ExitCode;
+					processExitCode = p.ExitCode;
 
 					// Throw an exception after the program exits if the code is not zero. Include all recorded output.
 					if( processExitCode != 0 )
 						throw new ApplicationException( $"Process exited with non-zero code '{processExitCode}'." );
-
-					return sbOutput.ToString();
 				}
 				catch( Exception ex ) {
-					string output = null, error = null;
-					try {
-						output = sbOutput.ToString();
-						error = sbError.ToString();
-					}
-					catch { }
-
-					throw new RunProgramException( null, $"An exception was thrown. {nameof(program)}: {program}. {nameof(arguments)}: {arguments}", output, error, ex );
+					throw new RunProgramException( $"An exception was thrown. {nameof(program)}: {program}. {nameof(arguments)}: {arguments}", processExitCode, ex );
 				}
 				finally {
 					ensureProcessExited( p );
 				}
 			}
 			catch( Exception ex ) when( !( ex is RunProgramException ) ) {
-				throw new RunProgramException(
-					null,
-					$"An exception was thrown. {nameof(program)}: {program}. {nameof(arguments)}: {arguments}",
-					processOutput: null,
-					processError: null,
-					ex );
+				throw new RunProgramException( $"An exception was thrown. {nameof(program)}: {program}. {nameof(arguments)}: {arguments}", null, ex );
 			}
 		}
 
 		/// <summary>
 		/// Appends the output as long as the data is not null.
 		/// </summary>
-		private static void getOutputHandler( DataReceivedEventArgs args, StringBuilder output ) {
+		private static void getOutputHandler( DataReceivedEventArgs args, Action<string> output ) {
 			if( args.Data == null )
 				return;
-			output.AppendLine( args.Data );
+			output( args.Data );
 		}
 
 		private static void ensureProcessExited( Process process ) {

--- a/Tewl/Tools/ProcessTools.cs
+++ b/Tewl/Tools/ProcessTools.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
-using System.IO;
+using System.Text;
+using Tewl.Exceptions;
 
 namespace Tewl.Tools {
 	/// <summary>
@@ -8,76 +9,104 @@ namespace Tewl.Tools {
 	/// </summary>
 	public static class ProcessTools {
 		/// <summary>
-		/// GMS NOTE: Sam has a better version of this.
-		/// Runs the specified program with the specified arguments and passes in the specified input. Optionally waits for the program to exit, and throws an
+		/// Runs the specified program with the specified arguments and passes in the specified input. Waits for the program to exit, and throws an
 		/// exception if this is specified and a nonzero exit code is returned. If the program is in a folder that is included in the Path environment variable,
-		/// specify its name only. Otherwise, specify a path to the program. In either case, you do NOT need ".exe" at the end. Specify the empty string for input
+		/// specify its name only. Otherwise, specify a path to the program. In either case, you do not need ".exe" at the end. Specify the empty string for input
 		/// if you do not wish to pass any input to the program.
-		/// Returns the output of the program if waitForExit is true.  Otherwise, returns the empty string.
+		/// Returns the output of the program.
 		/// </summary>
-		/// <param name="program"></param>
+		/// <param name="program">A command or exe.</param>
 		/// <param name="arguments">Do not pass null.</param>
 		/// <param name="input">Do not pass null.</param>
-		/// <param name="waitForExit"></param>
 		/// <param name="workingDirectory">Do not pass null. Pass the empty string for the current working directory.</param>
-		public static string RunProgram( string program, string arguments, string input, bool waitForExit, string workingDirectory = "" ) {
-			var outputResult = "";
-			using( var p = new Process() ) {
+		/// <param name="waitForExitTimeout">Waits for given duration for the program exists before throwing an exception.</param>
+		/// <exception cref="RunProgramException">When any error occurs.</exception>
+		/// <returns>The output of the program.</returns>
+		public static string RunProgram( string program, string arguments, string input = "", string workingDirectory = "", TimeSpan? waitForExitTimeout = null ) {
+			Process p = null;
+			var sbOutput = new StringBuilder();
+			var sbError = new StringBuilder();
+			try {
+				p = new Process();
 				p.StartInfo.FileName = program;
 				p.StartInfo.Arguments = arguments;
 				p.StartInfo.CreateNoWindow = true; // prevents command window from appearing
 				p.StartInfo.UseShellExecute = false; // necessary for redirecting output
 				p.StartInfo.WorkingDirectory = workingDirectory;
+
 				p.StartInfo.RedirectStandardInput = true;
-				if( waitForExit ) {
-					// Set up output recording.
-					p.StartInfo.RedirectStandardOutput = true;
-					p.StartInfo.RedirectStandardError = true;
-					var output = new StringWriter();
-					var errorOutput = new StringWriter();
-					p.OutputDataReceived += ( ( sender, e ) => output.WriteLine( e.Data ) );
-					p.ErrorDataReceived += ( ( sender, e ) => errorOutput.WriteLine( e.Data ) );
 
-					p.Start();
+				// Set up output recording.
+				p.StartInfo.RedirectStandardOutput = true;
+				p.StartInfo.RedirectStandardError = true;
 
-					// Begin recording output.
-					p.BeginOutputReadLine();
-					p.BeginErrorReadLine();
+				p.OutputDataReceived += ( o, args ) => getOutputHandler( args, sbOutput );
+				p.ErrorDataReceived += ( o, args ) => getOutputHandler( args, sbError );
 
-					// Pass input to the program.
-					if( input.Length > 0 ) {
-						p.StandardInput.Write( input );
-						p.StandardInput.Flush();
-					}
+				if( !p.Start() )
+					throw new ApplicationException( "Process failed to start." );
 
-					// Throw an exception after the program exits if the code is not zero. Include all recorded output.
-					p.WaitForExit();
-					outputResult = output.ToString();
-					if( p.ExitCode != 0 )
-						using( var sw = new StringWriter() ) {
-							sw.WriteLine( "Program exited with a nonzero code." );
-							sw.WriteLine();
-							sw.WriteLine( "Program: " + program );
-							sw.WriteLine( "Arguments: " + arguments );
-							sw.WriteLine();
-							sw.WriteLine( "Output:" );
-							sw.WriteLine( outputResult );
-							sw.WriteLine();
-							sw.WriteLine( "Error output:" );
-							sw.WriteLine( errorOutput.ToString() );
-							throw new ApplicationException( sw.ToString() );
-						}
-				}
-				else {
-					p.Start();
-					if( input.Length > 0 ) {
-						p.StandardInput.Write( input );
-						p.StandardInput.Flush();
-					}
+				// Begin recording output.
+				p.BeginOutputReadLine();
+				p.BeginErrorReadLine();
+
+				// Pass input to the program.
+				if( input.Length > 0 ) {
+					p.StandardInput.Write( input );
+					p.StandardInput.Flush();
 				}
 
-				return outputResult;
+				if( waitForExitTimeout != null && !p.WaitForExit( (int)waitForExitTimeout.Value.TotalMilliseconds ) )
+					throw new ApplicationException( $"Process did not exit within timeout '{waitForExitTimeout}'." );
+
+				/* When standard output has been redirected to asynchronous event handlers, it is possible that output processing will not
+				 * have completed when this method returns. To ensure that asynchronous event handling has been completed, call the WaitForExit()
+				 * overload that takes no parameter after receiving a true from this overload.
+				 * https://msdn.microsoft.com/en-us/library/ty0d8k56(v=vs.110)
+				 */
+				// This will wait infinitely.
+				p.WaitForExit();
+
+				var processExitCode = p.ExitCode;
+
+				// Throw an exception after the program exits if the code is not zero. Include all recorded output.
+				if( processExitCode != 0 )
+					throw new ApplicationException( $"Process exited with non-zero code '{processExitCode}'." );
+
+				return sbOutput.ToString();
 			}
+			catch( Exception ex ) {
+				string output = null, error = null;
+				try {
+					output = sbOutput.ToString();
+					error = sbError.ToString();
+				}
+				catch { }
+
+				throw new RunProgramException( null, $"An exception was thrown. {nameof(program)}: {program}. {nameof(arguments)}: {arguments}", output, error, ex );
+			}
+			finally {
+				ensureProcessExited( p );
+			}
+		}
+
+		/// <summary>
+		/// Appends the output as long as the data is not null.
+		/// </summary>
+		private static void getOutputHandler( DataReceivedEventArgs args, StringBuilder output ) {
+			if( args.Data == null )
+				return;
+			output.AppendLine( args.Data );
+		}
+
+		private static void ensureProcessExited( Process process ) {
+			if( !process?.HasExited ?? false )
+				try {
+					process.Kill();
+				}
+				catch { }
+
+			process?.Dispose();
 		}
 	}
 }

--- a/Tewl/Tools/ProcessTools.cs
+++ b/Tewl/Tools/ProcessTools.cs
@@ -9,8 +9,7 @@ namespace Tewl.Tools {
 	/// </summary>
 	public static class ProcessTools {
 		/// <summary>
-		/// Runs the specified program with the specified arguments and passes in the specified input. Waits for the program to exit, and throws an
-		/// exception if this is specified and a nonzero exit code is returned. If the program is in a folder that is included in the Path environment variable,
+		/// Runs the specified program with the specified arguments and passes in the specified input. If the program is in a folder that is included in the Path environment variable,
 		/// specify its name only. Otherwise, specify a path to the program. In either case, you do not need ".exe" at the end. Specify the empty string for input
 		/// if you do not wish to pass any input to the program.
 		/// Returns the output of the program.
@@ -19,11 +18,11 @@ namespace Tewl.Tools {
 		/// <param name="arguments">Do not pass null.</param>
 		/// <param name="input">Do not pass null.</param>
 		/// <param name="workingDirectory">Do not pass null. Pass the empty string for the current working directory.</param>
-		/// <param name="waitForExitTimeout">Waits for given duration for the program exists before throwing an exception.</param>
+		/// <param name="waitForExitTimeout">Waits for given duration for the program exists before throwing an exception. Null will wait for exit indefinitely.!</param>
 		/// <exception cref="RunProgramException">When any error occurs.</exception>
 		/// <returns>The output of the program.</returns>
 		public static string RunProgram( string program, string arguments, string input = "", string workingDirectory = "", TimeSpan? waitForExitTimeout = null ) {
-			Process p = null;
+			Process p;
 			var sbOutput = new StringBuilder();
 			var sbError = new StringBuilder();
 			try {
@@ -46,47 +45,57 @@ namespace Tewl.Tools {
 				if( !p.Start() )
 					throw new ApplicationException( "Process failed to start." );
 
-				// Begin recording output.
-				p.BeginOutputReadLine();
-				p.BeginErrorReadLine();
+				try {
+					// Begin recording output.
+					p.BeginOutputReadLine();
+					p.BeginErrorReadLine();
 
-				// Pass input to the program.
-				if( input.Length > 0 ) {
-					p.StandardInput.Write( input );
-					p.StandardInput.Flush();
-				}
+					// Pass input to the program.
+					if( input.Length > 0 ) {
+						p.StandardInput.Write( input );
+						p.StandardInput.Flush();
+					}
 
-				if( waitForExitTimeout != null && !p.WaitForExit( (int)waitForExitTimeout.Value.TotalMilliseconds ) )
-					throw new ApplicationException( $"Process did not exit within timeout '{waitForExitTimeout}'." );
+					if( waitForExitTimeout != null && !p.WaitForExit( (int)waitForExitTimeout.Value.TotalMilliseconds ) )
+						throw new ApplicationException( $"Process did not exit within timeout '{waitForExitTimeout}'." );
 
-				/* When standard output has been redirected to asynchronous event handlers, it is possible that output processing will not
+					/* When standard output has been redirected to asynchronous event handlers, it is possible that output processing will not
 				 * have completed when this method returns. To ensure that asynchronous event handling has been completed, call the WaitForExit()
 				 * overload that takes no parameter after receiving a true from this overload.
 				 * https://msdn.microsoft.com/en-us/library/ty0d8k56(v=vs.110)
 				 */
-				// This will wait infinitely.
-				p.WaitForExit();
+					// This will wait infinitely.
+					p.WaitForExit();
 
-				var processExitCode = p.ExitCode;
+					var processExitCode = p.ExitCode;
 
-				// Throw an exception after the program exits if the code is not zero. Include all recorded output.
-				if( processExitCode != 0 )
-					throw new ApplicationException( $"Process exited with non-zero code '{processExitCode}'." );
+					// Throw an exception after the program exits if the code is not zero. Include all recorded output.
+					if( processExitCode != 0 )
+						throw new ApplicationException( $"Process exited with non-zero code '{processExitCode}'." );
 
-				return sbOutput.ToString();
-			}
-			catch( Exception ex ) {
-				string output = null, error = null;
-				try {
-					output = sbOutput.ToString();
-					error = sbError.ToString();
+					return sbOutput.ToString();
 				}
-				catch { }
+				catch( Exception ex ) {
+					string output = null, error = null;
+					try {
+						output = sbOutput.ToString();
+						error = sbError.ToString();
+					}
+					catch { }
 
-				throw new RunProgramException( null, $"An exception was thrown. {nameof(program)}: {program}. {nameof(arguments)}: {arguments}", output, error, ex );
+					throw new RunProgramException( null, $"An exception was thrown. {nameof(program)}: {program}. {nameof(arguments)}: {arguments}", output, error, ex );
+				}
+				finally {
+					ensureProcessExited( p );
+				}
 			}
-			finally {
-				ensureProcessExited( p );
+			catch( Exception ex ) when( !( ex is RunProgramException ) ) {
+				throw new RunProgramException(
+					null,
+					$"An exception was thrown. {nameof(program)}: {program}. {nameof(arguments)}: {arguments}",
+					processOutput: null,
+					processError: null,
+					ex );
 			}
 		}
 


### PR DESCRIPTION
- Removed parameter `waitForExit`. Not usages in EWL exist. 
- Added parameter `waitForExitTimeout` for timeout to wait for process exit.
- Throw an exception when a process fails to start.
- Always throw `RunProgramException` to make it easier to catch exceptions related to this method. Includes command line, exit code, program output.
- Forces the program to have exited before method return.