### PR TITLE
CollectionTools improvements

### DIFF
--- a/Tewl/Tools/CollectionTools.cs
+++ b/Tewl/Tools/CollectionTools.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using JetBrains.Annotations;
 
 namespace Tewl.Tools;
@@ -42,22 +41,27 @@ public static class CollectionTools {
 	/// <summary>
 	/// Convenience method to allow concatenating individual elements.
 	/// </summary>
-	public static IEnumerable<T> ConcatItems<T>( this IEnumerable<T> items, params T[] ts ) => Enumerable.Concat( items, ts );
+	public static IEnumerable<T> ConcatItems<T>( this IEnumerable<T> items, params T[] ts ) => items.Concat( ts );
 
 	/// <summary>
 	/// Convenience method to allow concatenating individual elements to an existing array.
 	/// </summary>
-	public static T[] ConcatArray<T>( this IEnumerable<T> items, params T[] ts ) => Enumerable.Concat( items, ts ).ToArray();
+	public static T[] ConcatArray<T>( this IEnumerable<T> items, params T[] ts ) => items.Concat( ts ).ToArray();
 
 	/// <summary>
 	/// Creates a collection from this sequence.
 	/// </summary>
-	public static IReadOnlyCollection<T> Materialize<T>( this IEnumerable<T> items ) => items.ToImmutableArray();
+	public static IReadOnlyCollection<T> Materialize<T>( this IEnumerable<T> items ) => items.ToArray();
+
+	/// <summary>
+	/// Creates a list from this sequence, enabling elements to be accessed by index.
+	/// </summary>
+	public static IReadOnlyList<T> MaterializeAsList<T>( this IEnumerable<T> items ) => items.ToList();
 
 	/// <summary>
 	/// Creates a collection containing only this item.
 	/// </summary>
-	public static IReadOnlyCollection<T> ToCollection<T>( this T item ) => ImmutableArray.Create( item );
+	public static IReadOnlyCollection<T> ToCollection<T>( this T item ) => [ item ];
 
 	/// <summary>
 	/// Returns an enumerable of functions that return the given items.

--- a/Tewl/Tools/CollectionTools.cs
+++ b/Tewl/Tools/CollectionTools.cs
@@ -1,69 +1,70 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using JetBrains.Annotations;
 
-namespace Tewl.Tools {
+namespace Tewl.Tools;
+
+/// <summary>
+/// Tools for collections.
+/// </summary>
+[ PublicAPI ]
+public static class CollectionTools {
 	/// <summary>
-	/// Tools for collections.
+	/// Sorts the list alphabetically (ascending) based on the ToString value of each element.
 	/// </summary>
-	[ PublicAPI ]
-	public static class CollectionTools {
-		/// <summary>
-		/// Sorts the list alphabetically (ascending) based on the ToString value of each element.
-		/// </summary>
-		public static void SortAlphabetically<T>( this List<T> list ) => list.Sort( ( one, two ) => one.ToString().CompareTo( two.ToString() ) );
+	public static void SortAlphabetically<T>( this List<T> list ) => list.Sort( ( one, two ) => one.ToString().CompareTo( two.ToString() ) );
 
-		/// <summary>
-		/// Adds default(T) to the given list until the desired length is reached.
-		/// </summary>
-		public static List<T> Pad<T>( this IEnumerable<T> enumeration, int length ) => enumeration.Pad( length, () => default );
+	/// <summary>
+	/// Adds default(T) to the given list until the desired length is reached.
+	/// </summary>
+	public static List<T> Pad<T>( this IEnumerable<T> enumeration, int length ) => enumeration.Pad( length, () => default );
 
-		/// <summary>
-		/// Adds the given placeholder item to the given list until the desired length is reached.
-		/// </summary>
-		public static List<T> Pad<T>( this IEnumerable<T> enumeration, int length, Func<T> getNewPlaceholderItem ) {
-			var list = new List<T>( enumeration );
-			while( list.Count < length )
-				list.Add( getNewPlaceholderItem() );
-			return list;
-		}
-
-		/// <summary>
-		/// Transforms an IEnumerable into an IEnumerable of Tuple of two items while maintaining the order of the IEnumerable.
-		/// </summary>
-		public static IEnumerable<Tuple<A, B>> ToTupleEnumeration<A, B, T>( this IEnumerable<T> enumerable, Func<T, A> item1Selector, Func<T, B> item2Selector ) =>
-			enumerable.Select( e => Tuple.Create( item1Selector( e ), item2Selector( e ) ) );
-
-		/// <summary>
-		/// Gets the values that appear more than once in this sequence.
-		/// </summary>
-		public static IEnumerable<T> GetDuplicates<T>( this IEnumerable<T> items ) => items.GroupBy( i => i ).Where( i => i.Count() > 1 ).Select( i => i.Key );
-
-		/// <summary>
-		/// Convenience method to allow concatenating individual elements.
-		/// </summary>
-		public static IEnumerable<T> Concat<T>( this IEnumerable<T> items, params T[] ts ) => Enumerable.Concat( items, ts );
-
-		/// <summary>
-		/// Convenience method to allow concatenating individual elements to an existing array.
-		/// </summary>
-		public static T[] ConcatArray<T>( this IEnumerable<T> items, params T[] ts ) => Enumerable.Concat( items, ts ).ToArray();
-
-		/// <summary>
-		/// Creates a collection from this sequence.
-		/// </summary>
-		public static IReadOnlyCollection<T> Materialize<T>( this IEnumerable<T> items ) => items.ToImmutableArray();
-
-		/// <summary>
-		/// Creates a collection containing only this item.
-		/// </summary>
-		public static IReadOnlyCollection<T> ToCollection<T>( this T item ) => ImmutableArray.Create( item );
-
-		/// <summary>
-		/// Returns an enumerable of functions that return the given items.
-		/// </summary>
-		public static IEnumerable<Func<T>> ToFunctions<T>( this IEnumerable<T> items ) => items.Select<T, Func<T>>( i => () => i );
+	/// <summary>
+	/// Adds the given placeholder item to the given list until the desired length is reached.
+	/// </summary>
+	public static List<T> Pad<T>( this IEnumerable<T> enumeration, int length, Func<T> getNewPlaceholderItem ) {
+		var list = new List<T>( enumeration );
+		while( list.Count < length )
+			list.Add( getNewPlaceholderItem() );
+		return list;
 	}
+
+	/// <summary>
+	/// Transforms an IEnumerable into an IEnumerable of Tuple of two items while maintaining the order of the IEnumerable.
+	/// </summary>
+	public static IEnumerable<Tuple<A, B>> ToTupleEnumeration<A, B, T>( this IEnumerable<T> enumerable, Func<T, A> item1Selector, Func<T, B> item2Selector ) =>
+		enumerable.Select( e => Tuple.Create( item1Selector( e ), item2Selector( e ) ) );
+
+	/// <summary>
+	/// Gets the values that appear more than once in this sequence.
+	/// </summary>
+	public static IEnumerable<T> GetDuplicates<T>( this IEnumerable<T> items ) => items.GroupBy( i => i ).Where( i => i.Count() > 1 ).Select( i => i.Key );
+
+	/// <summary>
+	/// Convenience method to allow concatenating individual elements.
+	/// </summary>
+	public static IEnumerable<T> ConcatItems<T>( this IEnumerable<T> items, params T[] ts ) => items.Concat( ts );
+
+	/// <summary>
+	/// Convenience method to allow concatenating individual elements to an existing array.
+	/// </summary>
+	public static T[] ConcatArray<T>( this IEnumerable<T> items, params T[] ts ) => items.Concat( ts ).ToArray();
+
+	/// <summary>
+	/// Creates a collection from this sequence.
+	/// </summary>
+	public static IReadOnlyCollection<T> Materialize<T>( this IEnumerable<T> items ) => items.ToArray();
+
+	/// <summary>
+	/// Creates a list from this sequence, enabling elements to be accessed by index.
+	/// </summary>
+	public static IReadOnlyList<T> MaterializeAsList<T>( this IEnumerable<T> items ) => items.ToList();
+
+	/// <summary>
+	/// Creates a collection containing only this item.
+	/// </summary>
+	public static IReadOnlyCollection<T> ToCollection<T>( this T item ) => [ item ];
+
+	/// <summary>
+	/// Returns an enumerable of functions that return the given items.
+	/// </summary>
+	public static IEnumerable<Func<T>> ToFunctions<T>( this IEnumerable<T> items ) => items.Select<T, Func<T>>( i => () => i );
 }


### PR DESCRIPTION
Changed Materialize to use ToArray, which is much better at gleaning the item count from LINQ expressions and therefore reduces memory reallocations for auto-growth. Also brought in MaterializeAsList from EWL.