### PR TITLE
New HTTP request methods

### DIFF
--- a/Tewl/Tewl.csproj
+++ b/Tewl/Tewl.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="MiniProfiler.Shared" Version="4.3.8" />
     <PackageReference Include="NodaTime" Version="3.2.0" />
-    <PackageReference Include="Polly" Version="7.2.4" />
+    <PackageReference Include="Polly.Core" Version="8.5.2" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/Tewl/Tools/HttpClientTools.cs
+++ b/Tewl/Tools/HttpClientTools.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly;
+using Polly.Retry;
 using StackExchange.Profiling;
 using Tewl.IO;
 
@@ -79,35 +80,47 @@ public static class HttpClientTools {
 	/// </summary>
 	public static void ExecuteRequestWithRetry(
 		bool requestIsIdempotent, Func<Task> method, string additionalHandledMessage = "", Action? persistentFailureHandler = null ) {
-		var policyBuilder = Policy.HandleInner<HttpRequestException>(
-			e => e.InnerException is SocketException { SocketErrorCode: SocketError.HostNotFound or SocketError.NoData } );
+		bool isHandled( Exception e ) {
+			if( e is HttpRequestException { InnerException: SocketException { SocketErrorCode: SocketError.HostNotFound or SocketError.NoData } } )
+				return true;
+			if( !requestIsIdempotent )
+				return false;
 
-		if( requestIsIdempotent ) {
-			policyBuilder.OrInner<TaskCanceledException>() // timeout
-				.OrInner<HttpRequestException>( e => e.InnerException is SocketException { SocketErrorCode: SocketError.ConnectionRefused } )
-				.OrInner<HttpRequestException>( e => e.StatusCode is HttpStatusCode.InternalServerError )
-				.OrInner<HttpRequestException>( e => e.StatusCode is HttpStatusCode.BadGateway );
+			if( e is TaskCanceledException ) // timeout
+				return true;
+			if( e is HttpRequestException { InnerException: SocketException { SocketErrorCode: SocketError.ConnectionRefused } } )
+				return true;
+			if( e is HttpRequestException { StatusCode: HttpStatusCode.InternalServerError or HttpStatusCode.BadGateway } )
+				return true;
 
-			if( additionalHandledMessage.Length > 0 )
-				policyBuilder = policyBuilder.OrInner<HttpRequestException>( e => e.Message.Contains( additionalHandledMessage ) );
+			return additionalHandledMessage.Length > 0 && e is HttpRequestException && e.Message.Contains( additionalHandledMessage );
 		}
 
-		var result = MiniProfiler.Current.Inline(
-			() => policyBuilder.WaitAndRetry( 7, attemptNumber => TimeSpan.FromSeconds( Math.Pow( 2, attemptNumber ) ) )
-				.ExecuteAndCapture(
-					() => Policy.HandleInner<HttpRequestException>( e => e.StatusCode is HttpStatusCode.ServiceUnavailable )
-						.WaitAndRetry( 11, attemptNumber => TimeSpan.FromSeconds( Math.Pow( 2, attemptNumber ) ) )
-						.Execute( () => Task.Run( method ).Wait() ) ),
-			"TEWL - Execute HTTP request with retry" );
-
-		if( result.Outcome == OutcomeType.Successful )
-			return;
-
-		if( persistentFailureHandler is not null && result.ExceptionType == ExceptionType.HandledByThisPolicy )
+		try {
+			using( MiniProfiler.Current.Step( "TEWL - Execute HTTP request with retry" ) )
+				new ResiliencePipelineBuilder().AddRetry( getRetryOptions( e => isHandled( e.InnerException! ), 7 ) )
+					.Build()
+					.Execute(
+						() => new ResiliencePipelineBuilder()
+							.AddRetry( getRetryOptions( e => e.InnerException is HttpRequestException { StatusCode: HttpStatusCode.ServiceUnavailable }, 11 ) )
+							.Build()
+							.Execute( () => Task.Run( method ).Wait() ) );
+		}
+		catch( Exception e ) {
+			if( persistentFailureHandler is null || !isHandled( e.InnerException! ) )
+				throw;
 			persistentFailureHandler();
-		else
-			throw result.FinalException;
+		}
 	}
+
+	private static RetryStrategyOptions getRetryOptions( Func<Exception, bool> predicate, int attemptCount ) =>
+		new()
+			{
+				ShouldHandle = predicateArguments => ValueTask.FromResult( predicateArguments.Outcome.Exception is {} exception && predicate( exception ) ),
+				BackoffType = DelayBackoffType.Exponential,
+				Delay = TimeSpan.FromSeconds( 2 ),
+				MaxRetryAttempts = attemptCount
+			};
 
 	/// <summary>
 	/// Executes a method that makes a request using <see cref="HttpClient"/>, retrying several times with exponential back-off in the event of network problems

--- a/Tewl/Tools/HttpClientTools.cs
+++ b/Tewl/Tools/HttpClientTools.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly;
@@ -169,6 +170,10 @@ public static class HttpClientTools {
 						   StatusCode: HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable
 					   } )
 					return new Result( new Failure( e.Message, true ) );
+
+				// Remove the AggregateException from the Task.Run line above.
+				if( exception is AggregateException )
+					ExceptionDispatchInfo.Capture( e ).Throw();
 			}
 			throw;
 		}

--- a/Tewl/Tools/HttpClientTools.cs
+++ b/Tewl/Tools/HttpClientTools.cs
@@ -15,6 +15,74 @@ namespace Tewl.Tools;
 /// </summary>
 [ PublicAPI ]
 public static class HttpClientTools {
+	/// <summary>
+	/// The result of a method that makes a request.
+	/// </summary>
+	[ PublicAPI ]
+	public class Result {
+		/// <summary>
+		/// Returns the failure, or null if the request was successful.
+		/// </summary>
+		public Failure? Failure { get; }
+
+		/// <summary>
+		/// HttpClientTools.ExecuteRequest use only.
+		/// </summary>
+		internal Result( Failure? failure ) {
+			Failure = failure;
+		}
+	}
+
+	/// <summary>
+	/// The result of a method that makes a request.
+	/// </summary>
+	[ PublicAPI ]
+	public class Result<T> {
+		private readonly T value;
+		private readonly Failure? failure;
+
+		/// <summary>
+		/// HttpClientTools.ExecuteRequest use only.
+		/// </summary>
+		internal Result( T value, Failure? failure ) {
+			this.value = value;
+			this.failure = failure;
+		}
+
+		/// <summary>
+		/// Returns the failure, or null if the request was successful.
+		/// </summary>
+		/// <param name="value">The value.</param>
+		public Failure? Failure( out T value ) {
+			value = this.value;
+			return failure;
+		}
+	}
+
+	/// <summary>
+	/// A request failure.
+	/// </summary>
+	[ PublicAPI ]
+	public class Failure {
+		/// <summary>
+		/// Gets the error message.
+		/// </summary>
+		public string Message { get; }
+
+		/// <summary>
+		/// Gets whether the server may have begun processing the request, which is important when deciding whether to retry a non-idempotent request.
+		/// </summary>
+		public bool RequestProcessingMayHaveBegun { get; }
+
+		/// <summary>
+		/// HttpClientTools.ExecuteRequest use only.
+		/// </summary>
+		internal Failure( string message, bool requestProcessingMayHaveBegun ) {
+			Message = message;
+			RequestProcessingMayHaveBegun = requestProcessingMayHaveBegun;
+		}
+	}
+
 	private class WriterContent( Action<Stream> bodyWriter ): HttpContent {
 		protected override Task SerializeToStreamAsync( Stream stream, TransportContext? context ) {
 			bodyWriter( stream );
@@ -35,26 +103,37 @@ public static class HttpClientTools {
 	}
 
 	/// <summary>
+	/// Makes a GET request for a text-based resource and returns its representation.
+	/// </summary>
+	public static Result<string?> GetText( this HttpClient client, string url, bool returnNullIfNotFound = false ) =>
+		ExecuteRequest( () => getText( client, url, returnNullIfNotFound ) );
+
+	/// <summary>
 	/// Makes a GET request for a text-based resource and returns its representation, retrying several times with exponential back-off in the event of network
 	/// problems or transient failures on the server. Use only from a background process that can tolerate a long delay.
 	/// </summary>
 	public static string? GetTextWithRetry( this HttpClient client, string url, bool returnNullIfNotFound = false, string additionalHandledMessage = "" ) {
 		try {
-			return ExecuteRequestWithRetry(
-				true,
-				async () => {
-					using var response = await client.GetAsync( url, HttpCompletionOption.ResponseHeadersRead );
-					if( returnNullIfNotFound && response.StatusCode == HttpStatusCode.NotFound )
-						return null;
-					response.EnsureSuccessStatusCode();
-					return await response.Content.ReadAsStringAsync();
-				},
-				additionalHandledMessage: additionalHandledMessage );
+			return ExecuteRequestWithRetry( true, () => getText( client, url, returnNullIfNotFound ), additionalHandledMessage: additionalHandledMessage );
 		}
 		catch( Exception e ) {
 			throw new Exception( $"A GET request for {url} failed.", e );
 		}
 	}
+
+	private static async Task<string?> getText( this HttpClient client, string url, bool returnNullIfNotFound ) {
+		using var response = await client.GetAsync( url, HttpCompletionOption.ResponseHeadersRead );
+		if( returnNullIfNotFound && response.StatusCode == HttpStatusCode.NotFound )
+			return null;
+		response.EnsureSuccessStatusCode();
+		return await response.Content.ReadAsStringAsync();
+	}
+
+	/// <summary>
+	/// Makes a GET request for a resource and writes its representation to a file at the specified path. Overwrites the destination file if it already exists.
+	/// </summary>
+	public static Result DownloadFile( this HttpClient client, string url, string destinationPath ) =>
+		ExecuteRequest( () => downloadFile( client, url, destinationPath ) );
 
 	/// <summary>
 	/// Makes a GET request for a resource and writes its representation to a file at the specified path, retrying several times with exponential back-off in the
@@ -62,17 +141,45 @@ public static class HttpClientTools {
 	/// destination file if it already exists.
 	/// </summary>
 	public static void DownloadFileWithRetry( this HttpClient client, string url, string destinationPath, string additionalHandledMessage = "" ) =>
-		ExecuteRequestWithRetry(
-			true,
-			async () => {
-				using var response = await client.GetAsync( url, HttpCompletionOption.ResponseHeadersRead );
-				response.EnsureSuccessStatusCode();
+		ExecuteRequestWithRetry( true, () => downloadFile( client, url, destinationPath ), additionalHandledMessage: additionalHandledMessage );
 
-				IoMethods.DeleteFile( destinationPath );
-				await using var fileStream = IoMethods.GetFileStreamForWrite( destinationPath );
-				await response.Content.CopyToAsync( fileStream );
-			},
-			additionalHandledMessage: additionalHandledMessage );
+	private static async Task downloadFile( this HttpClient client, string url, string destinationPath ) {
+		using var response = await client.GetAsync( url, HttpCompletionOption.ResponseHeadersRead );
+		response.EnsureSuccessStatusCode();
+
+		IoMethods.DeleteFile( destinationPath );
+		await using var fileStream = IoMethods.GetFileStreamForWrite( destinationPath );
+		await response.Content.CopyToAsync( fileStream );
+	}
+
+	/// <summary>
+	/// Executes a method that makes a request using <see cref="HttpClient"/>.
+	/// </summary>
+	public static Result ExecuteRequest( Func<Task> method ) {
+		try {
+			using( MiniProfiler.Current.Step( "TEWL - Execute HTTP request" ) )
+				Task.Run( method ).Wait();
+		}
+		catch( Exception exception ) {
+			if( exception.InnerException is {} e ) {
+				if( preRequestProcessingFailureOccurred( e ) )
+					return new Result( new Failure( e.Message, false ) );
+				if( possibleRequestProcessingFailureOccurred( e ) || e is HttpRequestException { StatusCode: HttpStatusCode.TooManyRequests } )
+					return new Result( new Failure( e.Message, true ) );
+			}
+			throw;
+		}
+		return new Result( null );
+	}
+
+	/// <summary>
+	/// Executes a method that makes a request using <see cref="HttpClient"/>.
+	/// </summary>
+	public static Result<T> ExecuteRequest<T>( Func<Task<T>> method ) {
+		T? value = default;
+		var result = ExecuteRequest( async () => { value = await method(); } );
+		return new Result<T>( value!, result.Failure );
+	}
 
 	/// <summary>
 	/// Executes a method that makes a request using <see cref="HttpClient"/>, retrying several times with exponential back-off in the event of network problems
@@ -80,22 +187,6 @@ public static class HttpClientTools {
 	/// </summary>
 	public static void ExecuteRequestWithRetry(
 		bool requestIsIdempotent, Func<Task> method, string additionalHandledMessage = "", Action? persistentFailureHandler = null ) {
-		bool isHandled( Exception e ) {
-			if( e is HttpRequestException { InnerException: SocketException { SocketErrorCode: SocketError.HostNotFound or SocketError.NoData } } )
-				return true;
-			if( !requestIsIdempotent )
-				return false;
-
-			if( e is TaskCanceledException ) // timeout
-				return true;
-			if( e is HttpRequestException { InnerException: SocketException { SocketErrorCode: SocketError.ConnectionRefused } } )
-				return true;
-			if( e is HttpRequestException { StatusCode: HttpStatusCode.InternalServerError or HttpStatusCode.BadGateway } )
-				return true;
-
-			return additionalHandledMessage.Length > 0 && e is HttpRequestException && e.Message.Contains( additionalHandledMessage );
-		}
-
 		try {
 			using( MiniProfiler.Current.Step( "TEWL - Execute HTTP request with retry" ) )
 				new ResiliencePipelineBuilder().AddRetry( getRetryOptions( e => isHandled( e.InnerException! ), 7 ) )
@@ -106,10 +197,22 @@ public static class HttpClientTools {
 							.Build()
 							.Execute( () => Task.Run( method ).Wait() ) );
 		}
-		catch( Exception e ) {
-			if( persistentFailureHandler is null || !isHandled( e.InnerException! ) )
+		catch( Exception exception ) {
+			if( persistentFailureHandler is null || exception.InnerException is not {} e || !isHandled( e ) )
 				throw;
 			persistentFailureHandler();
+		}
+		return;
+
+		bool isHandled( Exception e ) {
+			if( preRequestProcessingFailureOccurred( e ) )
+				return true;
+			if( !requestIsIdempotent )
+				return false;
+
+			if( possibleRequestProcessingFailureOccurred( e ) )
+				return true;
+			return additionalHandledMessage.Length > 0 && e is HttpRequestException && e.Message.Contains( additionalHandledMessage );
 		}
 	}
 
@@ -121,6 +224,20 @@ public static class HttpClientTools {
 				Delay = TimeSpan.FromSeconds( 2 ),
 				MaxRetryAttempts = attemptCount
 			};
+
+	private static bool preRequestProcessingFailureOccurred( Exception e ) {
+		return e is HttpRequestException { InnerException: SocketException { SocketErrorCode: SocketError.HostNotFound or SocketError.NoData } };
+	}
+
+	private static bool possibleRequestProcessingFailureOccurred( Exception e ) {
+		if( e is TaskCanceledException ) // timeout
+			return true;
+		if( e is HttpRequestException { InnerException: SocketException { SocketErrorCode: SocketError.ConnectionRefused } } )
+			return true;
+		if( e is HttpRequestException { StatusCode: HttpStatusCode.InternalServerError or HttpStatusCode.BadGateway } )
+			return true;
+		return false;
+	}
 
 	/// <summary>
 	/// Executes a method that makes a request using <see cref="HttpClient"/>, retrying several times with exponential back-off in the event of network problems

--- a/Tewl/Tools/HttpClientTools.cs
+++ b/Tewl/Tools/HttpClientTools.cs
@@ -164,7 +164,10 @@ public static class HttpClientTools {
 			if( exception.InnerException is {} e ) {
 				if( preRequestProcessingFailureOccurred( e ) )
 					return new Result( new Failure( e.Message, false ) );
-				if( possibleRequestProcessingFailureOccurred( e ) || e is HttpRequestException { StatusCode: HttpStatusCode.TooManyRequests } )
+				if( possibleRequestProcessingFailureOccurred( e ) || e is HttpRequestException
+					   {
+						   StatusCode: HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable
+					   } )
 					return new Result( new Failure( e.Message, true ) );
 			}
 			throw;


### PR DESCRIPTION
The new methods make it easy to distinguish between a transient failure, represented with a Failure object in the result, and a true exception that should be addressed by developers.